### PR TITLE
Fix display null pointer exception on colorModes array.

### DIFF
--- a/services/core/java/com/android/server/display/LocalDisplayAdapter.java
+++ b/services/core/java/com/android/server/display/LocalDisplayAdapter.java
@@ -285,6 +285,9 @@ final class LocalDisplayAdapter extends DisplayAdapter {
                 int activeColorMode) {
             List<Integer> pendingColorModes = new ArrayList<>();
 
+            if (colorModes == null)
+                return false;
+
             // Build an updated list of all existing color modes.
             boolean colorModesAdded = false;
             for (int colorMode: colorModes) {


### PR DESCRIPTION
If HwC doesn't implement or support getColorModes, a null array is going
to be used by updateColorModesLocked inside LocalDisplayAdapter. So we
need to check for that and avoid a null pointer exception.