### PR TITLE
REVERTME: No Interent over Wi-Fi  Workaround

### DIFF
--- a/services/core/java/com/android/server/connectivity/NetworkMonitor.java
+++ b/services/core/java/com/android/server/connectivity/NetworkMonitor.java
@@ -632,6 +632,7 @@ public class NetworkMonitor extends StateMachine {
 
     @VisibleForTesting
     protected CaptivePortalProbeResult isCaptivePortal() {
+        mIsCaptivePortalCheckEnabled = false; //AIA-151 workaround
         if (!mIsCaptivePortalCheckEnabled) return new CaptivePortalProbeResult(204);
 
         URL pacUrl = null, httpsUrl = null, httpUrl = null, fallbackUrl = null;


### PR DESCRIPTION
Summary of the patch :- Disabling Captive Portal Check 

Description of the fix :-  Captive Portal check  has stopped in declaring if a network over Wi-Fi has internet access or not . As Enabling captive portal check would take some more time , it would remain disabled at least to resolve the "no internet" issue  as of now.

Jira: https://01.org/jira/browse/AIA-151

Test: Internet/browsing  over Wi-Fi should work .

Signed-off-by: atul.vaish@intel.com