### PR TITLE
Revert "REVERTME: No Interent over Wi-Fi Workaround"

### DIFF
--- a/services/core/java/com/android/server/connectivity/NetworkMonitor.java
+++ b/services/core/java/com/android/server/connectivity/NetworkMonitor.java
@@ -632,7 +632,6 @@ public class NetworkMonitor extends StateMachine {
 
     @VisibleForTesting
     protected CaptivePortalProbeResult isCaptivePortal() {
-        mIsCaptivePortalCheckEnabled = false; //AIA-151 workaround
         if (!mIsCaptivePortalCheckEnabled) return new CaptivePortalProbeResult(204);
 
         URL pacUrl = null, httpsUrl = null, httpUrl = null, fallbackUrl = null;


### PR DESCRIPTION
This reverts commit 945dddd74187d6824dd62227117c206c67b63294
as internet browsing over Wifi works without the workaround.

JIRA: NONE
Test: Internet browsing over Wifi.

Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>